### PR TITLE
Mark constructors as explicit to conform to the C++ standard

### DIFF
--- a/.github/workflows/cmake-static-analysis.yml
+++ b/.github/workflows/cmake-static-analysis.yml
@@ -30,4 +30,4 @@ jobs:
         use_cmake: true
         cmake_args: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -Wno-dev
 
-        cppcheck_args: --enable=all --suppress=missingIncludeSystem --suppress=unusedFunction --std=c++11
+        cppcheck_args: --enable=all --suppress=missingIncludeSystem --suppress=unusedFunction --std=c++11 --inline-suppr

--- a/.github/workflows/cmake-static-analysis.yml
+++ b/.github/workflows/cmake-static-analysis.yml
@@ -30,4 +30,4 @@ jobs:
         use_cmake: true
         cmake_args: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -Wno-dev
 
-        cppcheck_args: --enable=all --suppress=missingIncludeSystem --suppress=unusedFunction --std=c++11 --inline-suppr
+        cppcheck_args: --enable=all --suppress=missingIncludeSystem --suppress=unusedFunction --std=c++11

--- a/TestFramework.project
+++ b/TestFramework.project
@@ -591,7 +591,7 @@ mkdir -p coverage &amp;&amp; cd coverage
 find .. -name '*.gcda' | xargs gcov -abcfmu
 find . -type f -not -name 'Test*.gcov' | xargs rm</Target>
         <Target Name="cppcheck">cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -Wno-dev
-cppcheck --project=compile_commands.json -itest -idemo --enable=all --suppress=missingIncludeSystem --suppress=unusedFunction</Target>
+cppcheck --project=compile_commands.json --enable=all --suppress=missingIncludeSystem --suppress=unusedFunction  --std=c++11 --inline-suppr</Target>
         <Target Name="cpack">cpack --config CPackConfig.cmake
 cpack --config CPackSourceConfig.cmake
 cpack -G DEB

--- a/include/internal/TestCPPExceptions.h
+++ b/include/internal/TestCPPExceptions.h
@@ -60,13 +60,13 @@ namespace TestCPP {
          * Construct an exception of this type with a string literal for
          *  its failure message.
          */
-        TestCPPException (const char * msg);
+        explicit TestCPPException (const char * msg);
 
         /**
          * Construct an exception of this type with a string object for
          *  its failure message.
          */
-        TestCPPException (string&& msg);
+        explicit TestCPPException (string&& msg);
     };
 
     /**
@@ -89,13 +89,13 @@ namespace TestCPP {
          * Construct an exception of this type with a string literal for
          *  its failure message.
          */
-        TestFailedException (const char * msg);
+        explicit TestFailedException (const char * msg);
 
         /**
          * Construct an exception of this type with a string literal for
          *  its failure message.
          */
-        TestFailedException (string&& msg);
+        explicit TestFailedException (string&& msg);
     };
 }
 

--- a/include/internal/TestCPPUtil.h
+++ b/include/internal/TestCPPUtil.h
@@ -65,6 +65,11 @@ namespace TestCPP {
          * @return The TestObjName, where it is verified that the name
          *          used to construct it was not null.
          */
+        //
+        // This is intended to be used for implicit conversions and copy
+        //  initialization.
+        //
+        // cppcheck-suppress noExplicitConstructor
         TestObjName (const char* name);
 
         /**


### PR DESCRIPTION
These constructors fall into the guideline of constructors that should be marked explicit.
They are converting constructors that are not intended to be used for implicit conversions and copy-initialization.

See https://en.cppreference.com/w/cpp/language/explicit From that site:
Specifies that a constructor [or conversion function (since C++11)] [or deduction guide (since C++17)] is explicit, that is, it cannot be used for implicit conversions and copy-initialization.

See https://en.cppreference.com/w/cpp/language/converting_constructor also.

Enable inline CPPCheck suppressions in the GitHub static analysis workflow and the local CPPCheck command in the CodeLite project for suppressing one instance of noExplicitConstructor where it is intended to be used for implicit conversions and copy-initialization.

Add inline suppression to TestCPPUtil.h for noExplicitConstructor.

Add --std=c++11 parameter argument to local CPPCheck check in project. Removed unnecessary ignores from the CPPCheck command arguments where it just needs a clean prior to running the cppcheck custom target because the build system it generated probably includes more than what should be analyzed by CPPCheck.