### PR TITLE
Fix Infer issue of type USE_AFTER_DELETE

### DIFF
--- a/infer-fix
+++ b/infer-fix
@@ -1,0 +1,8 @@
+src/TestCPPTestCase.cpp:203: error: Use After Delete
+  call to `std::unique_ptr::operator=()` eventually accesses `TestCPP::Util::no_destroy::get().__infer_backing_pointer` that was invalidated by `delete` on line 202.
+  201.                 cout.rdbuf(TestCase::stdoutOriginal.get().release());
+  202.                 delete TestCase::stdoutBuffer.get().get();
+  203.                 TestCase::stdoutBuffer.get() = nullptr;
+                       ^
+  204.             }
+  205.

--- a/infer-fix
+++ b/infer-fix
@@ -1,8 +1,0 @@
-src/TestCPPTestCase.cpp:203: error: Use After Delete
-  call to `std::unique_ptr::operator=()` eventually accesses `TestCPP::Util::no_destroy::get().__infer_backing_pointer` that was invalidated by `delete` on line 202.
-  201.                 cout.rdbuf(TestCase::stdoutOriginal.get().release());
-  202.                 delete TestCase::stdoutBuffer.get().get();
-  203.                 TestCase::stdoutBuffer.get() = nullptr;
-                       ^
-  204.             }
-  205.

--- a/src/TestCPPTestCase.cpp
+++ b/src/TestCPPTestCase.cpp
@@ -200,7 +200,6 @@ namespace TestCPP {
                 TestCase::stdoutCaptureCasesConstructed - 1)
             {
                 cout.rdbuf(TestCase::stdoutOriginal.get().release());
-                delete TestCase::stdoutBuffer.get().get();
                 TestCase::stdoutBuffer.get() = nullptr;
             }
 
@@ -212,7 +211,6 @@ namespace TestCPP {
                 TestCase::logCaptureCasesConstructed - 1)
             {
                 clog.rdbuf(TestCase::clogOriginal.get().release());
-                delete TestCase::clogBuffer.get().get();
                 TestCase::clogBuffer.get() = nullptr;
             }
 
@@ -224,7 +222,6 @@ namespace TestCPP {
                 TestCase::stderrCaptureCasesConstructed - 1)
             {
                 cerr.rdbuf(TestCase::stderrOriginal.get().release());
-                delete TestCase::stderrBuffer.get().get();
                 TestCase::stderrBuffer.get() = nullptr;
             }
 


### PR DESCRIPTION
Closes #91.
This one was a big deal, so important to research and get this fixed.
Details in #91 with references to the std as to why I made the changes I made and how they fix the issues.
Infer pointed out 1 instance but there were actually 3 instances of the issue.