### PR TITLE
Closes #127 - the new structure is now taken into account.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,16 @@
   "SystemHeaders": false,
   "ExtraArgs": [
     "-Iinclude",
-    "-I3rdparty/include"
+    "-I3rdparty/boost.assert/include",
+    "-I3rdparty/boost.config/include",
+    "-I3rdparty/boost.container_hash/include",
+    "-I3rdparty/boost.core/include",
+    "-I3rdparty/boost.describe/include",
+    "-I3rdparty/boost.mp11/include",
+    "-I3rdparty/boost.predef/include",
+    "-I3rdparty/boost.stacktrace/include",
+    "-I3rdparty/boost.static_assert/include",
+    "-I3rdparty/boost.throw_exception/include",
+    "-I3rdparty/boost.winapi/include"
   ]
 }

--- a/cmake/build/MSVCDebug.cmake
+++ b/cmake/build/MSVCDebug.cmake
@@ -39,9 +39,18 @@ if (${TESTCPP_STACKTRACE_ENABLED})
         APPEND
         MSVC_DEBUG_BUILD_OPTS
 
-        "/external:I3rdparty/include" # Include the 3rdparty directory
-                                      #  as an external include
-                                      #  directory.
+        # Include the 3rdparty dependency directories as external.
+        "/external:I3rdparty/boost.assert/include"
+        "/external:I3rdparty/boost.config/include"
+        "/external:I3rdparty/boost.container_hash/include"
+        "/external:I3rdparty/boost.core/include"
+        "/external:I3rdparty/boost.describe/include"
+        "/external:I3rdparty/boost.mp11/include"
+        "/external:I3rdparty/boost.predef/include"
+        "/external:I3rdparty/boost.stacktrace/include"
+        "/external:I3rdparty/boost.static_assert/include"
+        "/external:I3rdparty/boost.throw_exception/include"
+        "/external:I3rdparty/boost.winapi/include"
     )
 endif ()
 

--- a/cmake/build/MSVCRelease.cmake
+++ b/cmake/build/MSVCRelease.cmake
@@ -37,9 +37,18 @@ if (${TESTCPP_STACKTRACE_ENABLED})
         APPEND
         MSVC_RELEASE_BUILD_OPTS
 
-        "/external:I3rdparty/include" # Include the 3rdparty directory
-                                      #  as an external include
-                                      #  directory.
+        # Include the 3rdparty dependency directories as external.
+        "/external:I3rdparty/boost.assert/include"
+        "/external:I3rdparty/boost.config/include"
+        "/external:I3rdparty/boost.container_hash/include"
+        "/external:I3rdparty/boost.core/include"
+        "/external:I3rdparty/boost.describe/include"
+        "/external:I3rdparty/boost.mp11/include"
+        "/external:I3rdparty/boost.predef/include"
+        "/external:I3rdparty/boost.stacktrace/include"
+        "/external:I3rdparty/boost.static_assert/include"
+        "/external:I3rdparty/boost.throw_exception/include"
+        "/external:I3rdparty/boost.winapi/include"
     )
 endif ()
 


### PR DESCRIPTION
Updates the clang-tidy config and the MSVC builds.