### PR TITLE
Fix clang-cl compilation issues when building tests for clang-tidy analysis

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -154,7 +154,8 @@
       "installDir": "${sourceDir}/out/install/win32-msanalysis",
       "cacheVariables": {
         "CMAKE_C_FLAGS": "/analyze /analyze:external- /analyze:autolog /analyze:ruleset NativeRecommendedRules.ruleset",
-        "CMAKE_CXX_FLAGS": "/analyze /analyze:external- /analyze:autolog /analyze:ruleset NativeRecommendedRules.ruleset"
+        "CMAKE_CXX_FLAGS": "/analyze /analyze:external- /analyze:autolog /analyze:ruleset NativeRecommendedRules.ruleset",
+        "TESTCPP_TEST_ENABLED": "1"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -358,7 +359,8 @@
         "CMAKE_CXX_FLAGS": "-v -m32",
         "CMAKE_EXE_LINKER_FLAGS": "/machine:x86",
         "CMAKE_SYSTEM_PROCESSOR": "X86",
-        "TESTCPP_ANALYSIS_ENABLED": "1"
+        "TESTCPP_ANALYSIS_ENABLED": "1",
+        "TESTCPP_TEST_ENABLED":  "1"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {

--- a/include/internal/TestCPPAssertions.h
+++ b/include/internal/TestCPPAssertions.h
@@ -361,15 +361,15 @@ void TestCPP::Assertions::assertEquals<const char*, const char*>(
 
 /**
  * @brief Check that char*'s are not equal using strcmp.
- * @param expected The value that the actual value should not
- *                  be equivalent to.
- * @param actual The actual value that will be checked against
- *                  the expected value.
- * @param failureMessage Failure message that should be logged
- *                          if the assertion fails. This
- *                          defaults to a generic failure
- *                          message related to the assertion
- *                          type.
+ *
+ * @param shouldNotBe    The value that the actual value should not be
+ *                         equivalent to.
+ * @param actual         The actual value that will be checked against
+ *                         the expected value.
+ * @param failureMessage Failure message that should be logged if the
+ *                         assertion fails. This defaults to a generic
+ *                         failure message related to the assertion
+ *                         type.
  */
 template<>
 void TestCPP::Assertions::assertNotEquals<const char*, const char*>(

--- a/include/internal/TestCPPTestCase.h
+++ b/include/internal/TestCPPTestCase.h
@@ -96,20 +96,23 @@ namespace TestCPP {
 
         /**
          * @brief Construct a test case with possibility to use all
-         *         options.
+         *          options.
          *
-         * @param testName The name of the test as a TestObjName.
-         * @param test The implementation or pointer to the test.
-         * @param testPassedMessage Whether to omit a message indicating
-         *          test passage.
-         * @param captureOut Whether to capture stdout output for
-         *          analysis after the test run.
-         * @param captureLog Whether to capture clog output for
-         *          analysis after the test run.
-         * @param captureErr Whether to capture stderr output for
-         *          analysis after the test run.
-         * @param opt Technique for comparing actual output with
-         *          expected output after the test run.
+         * @param name              The name of the test as a
+         *                            TestObjName.
+         * @param testFn            The implementation or pointer to
+         *                            the test.
+         * @param testPassedMessage Whether to omit a message
+         *                            indicating test passage.
+         * @param captureOut        Whether to capture stdout output
+         *                            for analysis after the test run.
+         * @param captureLog        Whether to capture clog output for
+         *                            analysis after the test run.
+         * @param captureErr        Whether to capture stderr output
+         *                            for analysis after the test run.
+         * @param opt               Technique for comparing actual
+         *                            output with expected output after
+         *                            the test run.
          *
          * Instantiate and define a test case.
          * All parameters are optional other than the test name and the
@@ -284,23 +287,29 @@ namespace TestCPP {
          *          active.
          */
         void captureStdErr ();
+
         /**
          * @brief Write a test failure reason to the specified stream.
-         * @param out The stream to write the test failure reason to.
-         * @param reason The test failure reason to write.
+         *
+         * @param out           The stream to write the test failure
+         *                        reason to.
+         * @param failureReason The test failure reason to write.
          */
         void logFailure (ostream& out, const string& failureReason) const;
         /**
          * @brief If a test encounters an error while running, this
          *          function will be called to log the test error.
-         * @param failureMessage The error message from the test that
-         *          should be logged.
+         *
+         * @param failureReason The error message from the test that
+         *                        should be logged.
          */
         void logTestFailure (const string& failureReason);
+
         /**
          * @brief Internal test run controller.
          */
         void runTest ();
+
         /**
          * @brief Handles the internal logic for calls to checkStdout,
          *          checkLog, and checkStderr based on the selected
@@ -336,9 +345,12 @@ namespace TestCPP {
 
         /**
          * @brief Measure the duration of a function when run.
+         *
          * @param func Measure the duration of this function when run.
          * @param args A template pack of arguments to apply to the
-         *          given function of which to measure the duration.
+         *               given function of which to measure the
+         *               duration.
+         *
          * @return The duration of the function run, in nanoseconds.
          */
         template<typename F, typename ...Args>

--- a/include/internal/TestCPPTestSuite.h
+++ b/include/internal/TestCPPTestSuite.h
@@ -87,10 +87,10 @@ namespace TestCPP {
          *          tests.
          */
         template<typename... TestType>
-        TestSuite (TestObjName&& newSuiteName, TestType ...tests)
+        TestSuite (TestObjName&& newSuiteName, TestType ...newSuiteTests)
         {
             commonInit(std::forward<TestObjName>(newSuiteName));
-            this->addTests(tests...);
+            this->addTests(newSuiteTests...);
         }
 
         /**
@@ -99,7 +99,7 @@ namespace TestCPP {
          * Appropriate specializations defined in the source file.
          */
         template<typename T>
-        void addTest (T&& test);
+        void addTest (T&& addTestToSuite);
 
         /**
          * @brief Specialization to handle when someone tries to call
@@ -113,13 +113,16 @@ namespace TestCPP {
 
         /**
          * @brief Add one or more tests at once to the test suite.
-         * @param test The first test to add.
-         * @param tests The rest of the tests to add.
+         *
+         * @param addTestToSuite         The first test to add.
+         * @param addTheseOtherTestsAlso The rest of the tests to add.
          */
         template<typename Test, typename... OtherTests>
-        void addTests (Test test, OtherTests ...tests) {
-            addTest(std::move(test));
-            addTests(tests...);
+        void addTests (Test addTestToSuite,
+                       OtherTests ...addTheseOtherTestsAlso)
+        {
+            addTest(std::move(addTestToSuite));
+            addTests(addTheseOtherTestsAlso...);
         }
 
         /**

--- a/test/src/TestCPPAssertionsBasicMain.cpp
+++ b/test/src/TestCPPAssertionsBasicMain.cpp
@@ -1,10 +1,12 @@
 #include "TestCPP.h"
 
-using TestCPP::TestCase;
-using TestCPP::TestSuite;
-using std::string;
-using std::make_tuple;
-using std::function;
+namespace TestCPP {
+    namespace Testing {
+        namespace AssertionsSuites {
+            extern TestSuite basicSuite;
+        }
+    }
+}
 
 #include "Assertions/AssertionsBasicSuite.h"
 

--- a/test/src/TestCPPExceptionsMain.cpp
+++ b/test/src/TestCPPExceptionsMain.cpp
@@ -1,10 +1,12 @@
 #include "TestCPP.h"
 
-using TestCPP::TestCase;
-using TestCPP::TestSuite;
-using std::string;
-using std::make_tuple;
-using std::function;
+namespace TestCPP {
+    namespace Testing {
+        namespace ExceptionsSuite {
+            extern TestSuite suite;
+        }
+    }
+}
 
 #include "Exceptions/ExceptionsSuite.h"
 

--- a/test/src/TestCPPTestCaseMain.cpp
+++ b/test/src/TestCPPTestCaseMain.cpp
@@ -1,10 +1,12 @@
 #include "TestCPP.h"
 
-using TestCPP::TestCase;
-using TestCPP::TestSuite;
-using std::string;
-using std::make_tuple;
-using std::function;
+namespace TestCPP {
+    namespace Testing {
+        namespace TestCaseSuite {
+            extern TestSuite suite;
+        }
+    }
+}
 
 #include "TestCase/TestCaseSuite.h"
 

--- a/test/src/TestCPPTestSuiteConstructionMain.cpp
+++ b/test/src/TestCPPTestSuiteConstructionMain.cpp
@@ -1,10 +1,12 @@
 #include "TestCPP.h"
 
-using TestCPP::TestCase;
-using TestCPP::TestSuite;
-using std::string;
-using std::make_tuple;
-using std::function;
+namespace TestCPP {
+    namespace Testing {
+        namespace TestSuiteSuites {
+            extern TestSuite ctorSuite;
+        }
+    }
+}
 
 #include "TestSuite/TestSuiteConstructionSuite.h"
 

--- a/test/src/TestCPPTestSuiteRunningMain.cpp
+++ b/test/src/TestCPPTestSuiteRunningMain.cpp
@@ -1,10 +1,12 @@
 #include "TestCPP.h"
 
-using TestCPP::TestCase;
-using TestCPP::TestSuite;
-using std::string;
-using std::make_tuple;
-using std::function;
+namespace TestCPP {
+    namespace Testing {
+        namespace TestSuiteSuites {
+            extern TestSuite runSuite;
+        }
+    }
+}
 
 #include "TestSuite/TestSuiteRunningSuite.h"
 

--- a/test/src/TestCPPTestSuiteTestPassedMessageMain.cpp
+++ b/test/src/TestCPPTestSuiteTestPassedMessageMain.cpp
@@ -1,10 +1,12 @@
 #include "TestCPP.h"
 
-using TestCPP::TestCase;
-using TestCPP::TestSuite;
-using std::string;
-using std::make_tuple;
-using std::function;
+namespace TestCPP {
+    namespace Testing {
+        namespace TestSuiteSuites {
+            extern TestSuite testPassedMessageSuite;
+        }
+    }
+}
 
 #include "TestSuite/TestSuiteTestPassedMessageSuite.h"
 

--- a/test/src/TestCase/TestCaseTests.cpp
+++ b/test/src/TestCase/TestCaseTests.cpp
@@ -1,4 +1,5 @@
 #include "TestCPP.h"
+#include "TestCase/TestCaseTests.h"
 #include "TestCase/TestCaseTestChunks.h"
 
 using TestCPP::Util::debugLog;
@@ -25,9 +26,10 @@ namespace TestCPP {
                         debugLog("Construct with nullptr string", true);
                         debugLog(" - assertThrows lambda");
 
-                        auto test = unique_ptr<TestCase>(new TestCase(
-                            nullptr,
-                            function<void()>([](){})
+                        auto testShouldThrow = unique_ptr<TestCase>(
+                            new TestCase(
+                                nullptr,
+                                function<void()>([](){})
                         ));
                     },
                     "Should have thrown on nullptr string!"
@@ -110,9 +112,20 @@ namespace TestCPP {
 
                 auto test = unique_ptr<TestCase>(new TestCase(
                     "SUB-TEST TestCaseGo case Test - throws str",
+#ifdef TESTCPP_STACKTRACE_ENABLED
+                    // We use C++14 when stacktraces are enabled, which
+                    //  allows us to avoid needing to use
+                    //  -Wno-unused-lambda-capture to avoid MSVC C3493
+                    //  since the implementations can be reconciled in
+                    //  the newer standard.
+                    function<void()>([&toThrow = throwStr](){
+                        throw toThrow;
+                    }),
+#else
                     function<void()>([&throwStr](){
                         throw throwStr;
                     }),
+#endif
                     true, false, true, false,
                     TestCase::TestCaseOutCompareOptions::CONTAINS
                 ));
@@ -134,9 +147,20 @@ namespace TestCPP {
 
                 auto test = unique_ptr<TestCase>(new TestCase(
                     "SUB-TEST TestCaseGo case Test - throws chr",
+#ifdef TESTCPP_STACKTRACE_ENABLED
+                    // We use C++14 when stacktraces are enabled, which
+                    //  allows us to avoid needing to use
+                    //  -Wno-unused-lambda-capture to avoid MSVC C3493
+                    //  since the implementations can be reconciled in
+                    //  the newer standard.
+                    function<void()>([&toThrow = throwChr](){
+                        throw toThrow;
+                    }),
+#else
                     function<void()>([&throwChr](){
                         throw throwChr;
                     }),
+#endif
                     true, false, true, false,
                     TestCase::TestCaseOutCompareOptions::CONTAINS
                 ));

--- a/test/src/TestSuite/TestSuiteRunningTests.cpp
+++ b/test/src/TestSuite/TestSuiteRunningTests.cpp
@@ -4,9 +4,9 @@
 namespace TestCPP {
     namespace Testing {
         namespace TestSuiteTests {
-            unsigned zero = 0;
-            unsigned one = 1;
-            unsigned three = 3;
+            static unsigned zero = 0;
+            static unsigned one = 1;
+            static unsigned three = 3;
 
             void TestSuiteRunNoTests() {
                 auto testSuite = unique_ptr<TestSuite>(new TestSuite(


### PR DESCRIPTION
There were a number of issues pointed out by the Windows clang-cl build trying to get it to build the project enough to run clang-tidy.

Closes #129.
Closes #128.