### PR TITLE
Use the best available platform-appropriate backend for Boost.Stacktrace

### DIFF
--- a/cmake/BuildTypeHandling.cmake
+++ b/cmake/BuildTypeHandling.cmake
@@ -7,7 +7,7 @@ endif ()
 if (${CMAKE_BUILD_TYPE} STREQUAL "Release")
     message (STATUS "Release build compilation options enabled")
 
-    if (MSVC AND NOT ("${CMAKE_VS_PLATFORM_TOOLSET}" STREQUAL "ClangCL"))
+    if (MSVC)
         message (STATUS "MSVC Release build compilation options enabled")
 
         include (MSVCRelease)
@@ -23,7 +23,7 @@ else ()
 
     include (DebugCompileDefs)
     
-    if (MSVC AND NOT ("${CMAKE_VS_PLATFORM_TOOLSET}" STREQUAL "ClangCL"))
+    if (MSVC)
         message (STATUS "MSVC Debug build compilation options enabled")
 
         include (MSVCDebug)

--- a/cmake/build/CompileDefs.cmake
+++ b/cmake/build/CompileDefs.cmake
@@ -1,5 +1,5 @@
 if (${TESTCPP_STACKTRACE_ENABLED})
-    if (MSVC AND ("${CMAKE_VS_PLATFORM_TOOLSET}" STREQUAL "ClangCL"))
+    if (MSVC)
         target_compile_definitions (
             ${PROJECT_NAME}
             PUBLIC
@@ -7,10 +7,36 @@ if (${TESTCPP_STACKTRACE_ENABLED})
                 BOOST_STACKTRACE_USE_WINDBG
         )
     else ()
-        target_compile_definitions (
-            ${PROJECT_NAME}
-            PUBLIC
-                TESTCPP_STACKTRACE_ENABLED
-        )
+        find_package (Backtrace)
+        if (Backtrace_FOUND)
+            set (TESTCPP_INTERNAL_PREFER_BACKTRACE true)
+            target_compile_definitions (
+                ${PROJECT_NAME}
+                PUBLIC
+                    TESTCPP_STACKTRACE_ENABLED
+                    # We don't know yet if Boost.Stacktrace has
+                    #  Backtrace support, we will know during the
+                    #  Linking phase and will add this if it does.
+                    #BOOST_STACKTRACE_USE_BACKTRACE
+            )
+        else ()
+            set (TESTCPP_INTERNAL_PREFER_BACKTRACE false)
+            # See https://github.com/Kitware/CMake/blob/v3.30.2/Modules/CMakeFindBinUtils.cmake
+            # Also see https://cmake.org/cmake/help/v3.30/command/find_program.html
+            if (DEFINED CMAKE_ADDR2LINE AND NOT (${CMAKE_ADDR2LINE} STREQUAL "CMAKE_ADDR2LINE-NOTFOUND"))
+                target_compile_definitions (
+                    ${PROJECT_NAME}
+                    PUBLIC
+                        TESTCPP_STACKTRACE_ENABLED
+                        BOOST_STACKTRACE_USE_ADDR2LINE
+                )
+            else ()
+                target_compile_definitions (
+                    ${PROJECT_NAME}
+                    PUBLIC
+                        TESTCPP_STACKTRACE_ENABLED
+                )
+            endif ()
+        endif ()
     endif ()
 endif ()

--- a/cmake/link/Boost.Stacktrace.cmake
+++ b/cmake/link/Boost.Stacktrace.cmake
@@ -60,12 +60,19 @@ if (MSVC)
 # First try Backtrace for Linux, then addr2line, and finally the default Boost.Stacktrace.
 else ()
     find_package (Backtrace)
-    if ((${BOOST_STACKTRACE_HAS_BACKTRACE}) AND (DEFINED Backtrace_FOUND))
+    if ((${BOOST_STACKTRACE_HAS_BACKTRACE}) AND (DEFINED Backtrace_FOUND) AND (${TESTCPP_INTERNAL_PREFER_BACKTRACE}))
         list (
             APPEND
             BOOST_STACKTRACE_EXPORTS_LIST
 
             boost_stacktrace_backtrace
+        )
+        target_compile_definitions (
+            ${PROJECT_NAME}
+            PUBLIC
+                TESTCPP_STACKTRACE_ENABLED
+                # Now we know this is available and preferred, use it.
+                BOOST_STACKTRACE_USE_BACKTRACE
         )
         target_link_libraries(
             ${PROJECT_NAME}


### PR DESCRIPTION
Also, use MSVC build for clang-cl.

Closes #131.
Closes #132.