### PR TITLE
Fix a number of issues running clang-tidy in clang-cl on Windows, et al.

### DIFF
--- a/cmake/build/GCCClangDebug.cmake
+++ b/cmake/build/GCCClangDebug.cmake
@@ -22,25 +22,31 @@ list (
                                 #  building for Clang, GCC, and MSVC,
                                 #  and MSVC has different pragmas than
                                 #  GCC/Clang.
-    -Wno-unused-lambda-capture  # Avoid MSVC error C3493 - There is
-                                #  implementation divergence here and
-                                #  since we're not using >=C++14 there
-                                #  is no workaround other than to ignore
-                                #  this warning (the MSVC issue is an
-                                #  error).
-                                # A workaround for >=C++14 is to use an
-                                #  explicit capture - if ever I change
-                                #  the library to use >=C++14 I can
-                                #  remove this and use an explicit
-                                #  capture.
 )
+
+if (NOT (${TESTCPP_STACKTRACE_ENABLED}))
+    # If stack traces are enabled, we use C++14 features that make this
+    #  warning unnecessary, so we don't add it unless we need it.
+    list (
+        APPEND
+        GCC_CLANG_DEBUG_BUILD_OPTS
+
+        -Wno-unused-lambda-capture # Avoid MSVC error C3493 - There is
+                                   #  implementation divergence here
+                                   #  and since we're not using >=C++14
+                                   #  there is no workaround other than
+                                   #  to ignore this warning (the MSVC
+                                   #  issue is an error).
+                                   # A workaround for >=C++14 is to use
+                                   #  an explicit capture.
+    )
+endif ()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # GCC doesn't support -Wno-global-constructors yet, so only add it
     #  if we are building with Clang, either with MSVC as a frontend
     #  or straight-up LLVM.
     # Ref https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71482
-
     list (
         APPEND
 

--- a/cmake/build/GCCClangRelease.cmake
+++ b/cmake/build/GCCClangRelease.cmake
@@ -21,25 +21,31 @@ list (
                                 #  GCC/Clang.
     -Wno-unused-parameter       # Unused parameters occur in the Release
                                 #  build in debugLog.
-    -Wno-unused-lambda-capture  # Avoid MSVC error C3493 - There is
-                                #  implementation divergence here and
-                                #  since we're not using >=C++14 there
-                                #  is no workaround other than to ignore
-                                #  this warning (the MSVC issue is an
-                                #  error).
-                                # A workaround for >=C++14 is to use an
-                                #  explicit capture - if ever I change
-                                #  the library to use >=C++14 I can
-                                #  remove this and use an explicit
-                                #  capture.
 )
+
+if (NOT (${TESTCPP_STACKTRACE_ENABLED}))
+    # If stack traces are enabled, we use C++14 features that make this
+    #  warning unnecessary, so we don't add it unless we need it.
+    list (
+        APPEND
+        GCC_CLANG_DEBUG_BUILD_OPTS
+
+        -Wno-unused-lambda-capture # Avoid MSVC error C3493 - There is
+                                   #  implementation divergence here
+                                   #  and since we're not using >=C++14
+                                   #  there is no workaround other than
+                                   #  to ignore this warning (the MSVC
+                                   #  issue is an error).
+                                   # A workaround for >=C++14 is to use
+                                   #  an explicit capture.
+    )
+endif ()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # GCC doesn't support -Wno-global-constructors yet, so only add it
     #  if we are building with Clang, either with MSVC as a frontend
     #  or straight-up LLVM.
     # Ref https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71482
-
     list (
         APPEND
         GCC_CLANG_RELEASE_BUILD_OPTS

--- a/cmake/build/MSVCDebug.cmake
+++ b/cmake/build/MSVCDebug.cmake
@@ -6,8 +6,6 @@ list (
                             #  copyright information.
     /Zi                     # Generate complete debugging information.
     /FS                     # Force synchronous PDB writes.
-    /EHscr                  # Enable C++ exceptions, including RTCs for
-                            #  noexcept verification at runtime.
     /RTC1                   # Enable Runtime Checks.
     /Wall                   # Enable all warnings and treat them as
                             #  errors.
@@ -26,10 +24,6 @@ list (
                             #  /Qspectre is specified.
                             # Applied this warning suppression since
                             #  /Qspectre is specified.
-    /Qspectre               # Instructs the compiler to apply Spectre
-                            #  vulnerability mitigations.
-    /external:anglebrackets # Treat angle-bracket includes as system
-                            #  includes.
     /external:W0            # Suppress all warnings from external
                             #  headers.
 )
@@ -63,6 +57,97 @@ if ("${CMAKE_CXX_FLAGS}" MATCHES "/analyze:ruleset")
     )
 endif ()
 
+if (NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
+    list (
+        APPEND
+        MSVC_DEBUG_BUILD_OPTS
+
+        /EHscr                  # Enable C++ exceptions, including RTCs
+                                #  for noexcept verification at
+                                #  runtime, only if using CL.
+        /Qspectre               # Instructs the compiler to apply
+                                #  Spectre vulnerability mitigations.
+        /external:anglebrackets # Treat angle-bracket includes as
+                                #  system includes.
+    )
+else ()
+    # If using clang-cl, we need some additional/altered flags
+    list (
+        APPEND
+        MSVC_DEBUG_BUILD_OPTS
+
+        /EHsc                      # Enable C++ exceptions, without
+                                   #  RTCs for noexcept verification at
+                                   #  runtime; clang-cl does not
+                                   #  support /EHscr.
+        -Wno-c++98-compat          # We're compiling for C++11, so it's
+                                   #  not necessary to maintain
+                                   #  compatibility with C++98.
+        -Wno-c++98-compat-pedantic # We're compiling for C++11, so,
+                                   #  again, it's not necessary to
+                                   #  maintain compatibility with
+                                   #  C++98.
+        -Wno-global-constructors   # The performance degradation
+                                   #  pointed out by this warning is
+                                   #  non-trivial but not enough to
+                                   #  work through any issues that
+                                   #  might be caused by it; there were
+                                   #  already constructors from built-
+                                   #  in types that were being called
+                                   #  (particularly unique_ptr), but
+                                   #  this points out that the type I
+                                   #  added (no_destroy) adds custom
+                                   #  and additional start-up code that
+                                   #  can change startup performance by
+                                   #  making it slower.
+                                   # How much slower is a matter of
+                                   #  micro-optimization for this
+                                   #  library project in particular,
+                                   #  but could significantly decrease
+                                   #  startup performance if there were
+                                   #  n-many of these objects being
+                                   #  created.
+                                   # At this point there are only 6, so
+                                   #  this should not cause a
+                                   #  noticeable hit to startup
+                                   #  performance.
+    )
+
+    if (NOT (${TESTCPP_STACKTRACE_ENABLED}))
+        # If stack traces are enabled, we use C++14 features that make
+        #  this warning suppression unnecessary, so we don't add it
+        #  unless we need it.
+        list (
+            APPEND
+            MSVC_DEBUG_BUILD_OPTS
+
+            -Wno-unused-lambda-capture # Avoid MSVC error C3493 - There
+                                       #  is implementation divergence
+                                       #  here and since we're not
+                                       #  using >=C++14 there is no
+                                       #  workaround other than to
+                                       #  ignore this warning (the MSVC
+                                       #  issue is an error).
+                                       # A workaround for >=C++14 is to
+                                       #  use an explicit capture.
+        )
+    endif ()
+
+    if (BUILD_TESTING)
+        list (
+            APPEND
+            MSVC_DEBUG_TEST_BUILD_OPTS
+
+            ${MSVC_DEBUG_BUILD_OPTS}
+            -Wno-undefined-func-template # Not a real problem
+            -Wno-exit-time-destructors   # This is not a concern for
+                                         #  test executables in this
+                                         #  project, it's a single
+                                         #  object that gets destroyed.
+        )
+    endif ()
+endif ()
+
 target_compile_options (
     ${PROJECT_NAME}
     PUBLIC
@@ -77,7 +162,41 @@ if (${TESTCPP_DEMO_ENABLED})
     )
 endif ()
 
-if (BUILD_TESTING)
+if (BUILD_TESTING AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
+    target_compile_options (
+        ${PROJECT_NAME}_test_TestCase
+        PUBLIC
+        ${MSVC_DEBUG_TEST_BUILD_OPTS}
+    )
+
+    target_compile_options (
+        ${PROJECT_NAME}_test_TestSuite_ctor
+        PUBLIC
+        ${MSVC_DEBUG_TEST_BUILD_OPTS}
+    )
+    target_compile_options (
+        ${PROJECT_NAME}_test_TestSuite_running
+        PUBLIC
+        ${MSVC_DEBUG_TEST_BUILD_OPTS}
+    )
+    target_compile_options (
+        ${PROJECT_NAME}_test_TestSuite_tpm
+        PUBLIC
+        ${MSVC_DEBUG_TEST_BUILD_OPTS}
+    )
+
+    target_compile_options (
+        ${PROJECT_NAME}_test_Assertions_basic
+        PUBLIC
+        ${MSVC_DEBUG_TEST_BUILD_OPTS}
+    )
+
+    target_compile_options (
+        ${PROJECT_NAME}_test_Exceptions
+        PUBLIC
+        ${MSVC_DEBUG_TEST_BUILD_OPTS}
+    )
+elseif (BUILD_TESTING)
     target_compile_options (
         ${PROJECT_NAME}_test_TestCase
         PUBLIC


### PR DESCRIPTION
Only ignore warnings when necessary.
Work through issues running clang-tidy on Windows with clang-cl.

Closes #139.